### PR TITLE
improve handling

### DIFF
--- a/modules/processing/procmemory.py
+++ b/modules/processing/procmemory.py
@@ -37,6 +37,9 @@ class ProcessMemory(Processing):
                     continue
 
                 dmp_path = os.path.join(self.pmemory_path, dmp)
+                if os.path.getsize(dmp_path) == 0:
+                    continue
+
                 dmp_file = File(dmp_path)
                 process_name = ""
                 process_path = ""


### PR DESCRIPTION
```
ValueError: cannot mmap an empty file
Exception AttributeError: "'ProcDump' object has no attribute 'dumpfile'" in <bound method ProcDump.__del__ of <lib.cuckoo.common.objects.ProcDump object at 0x7f1f335aae10>> ignored
```