### PR TITLE
Increase severity on registry PE

### DIFF
--- a/modules/signatures/CAPE.py
+++ b/modules/signatures/CAPE.py
@@ -105,7 +105,7 @@ class CAPE_Compression(Signature):
 class CAPE_RegBinary(Signature):
     name = "RegBinary"
     description = "Behavioural detection: PE binary written to registry."
-    severity = 1
+    severity = 3
     categories = ["malware"]
     authors = ["kevoreilly"]
     minimum = "1.3"


### PR DESCRIPTION
This is used in "fileless" attacks and I can't think of a legit reason this would be done.