### PR TITLE
Create signature for WMI creating a process

### DIFF
--- a/modules/signatures/wmi.py
+++ b/modules/signatures/wmi.py
@@ -17,7 +17,7 @@ from lib.cuckoo.common.abstracts import Signature
 
 class WMICreateProcess(Signature):
     name = "wmi_create_process"
-    description = "Attempted to create a process using Windows Management Instrumentation (WMI)"
+    description = "Windows Management Instrumentation (WMI) attempted to create a process"
     severity = 3
     confidence = 50
     categories = ["martians"]

--- a/modules/signatures/wmi.py
+++ b/modules/signatures/wmi.py
@@ -1,0 +1,42 @@
+# Copyright (C) 2019 Kevin Ross
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from lib.cuckoo.common.abstracts import Signature
+
+class WMICreateProcess(Signature):
+    name = "wmi_create_process"
+    description = "Attempted to create a process using Windows Management Instrumentation (WMI)"
+    severity = 3
+    categories = ["martians"]
+    authors = ["Kevin Ross"]
+    minimum = "1.3"
+    evented = True
+    ttp = ["T1047"]
+
+    def __init__(self, *args, **kwargs):
+        Signature.__init__(self, *args, **kwargs)
+        self.ret = False
+
+    filter_apinames = set(["CreateProcessInternalW"])
+
+    def on_call(self, call, process):
+        pname = process["process_name"]
+        if "wmiprvse" in pname.lower():
+            self.ret = True
+            cmdline = self.get_argument(call, "CommandLine")
+            self.data.append({"cmdline" : cmdline})
+
+    def on_complete(self):
+        return self.ret


### PR DESCRIPTION
Looking at WMI we can flag on this. For a lot of other WMI stuff it will need hooked like in Cuckoo 2

![image](https://user-images.githubusercontent.com/2414517/63516272-9a30fc80-c4e4-11e9-839b-0646feff03a2.png)

![image](https://user-images.githubusercontent.com/2414517/63516317-b2a11700-c4e4-11e9-9fbc-7840922c7ce7.png)
