### PR TITLE
Add in powershell C# compilation

### DIFF
--- a/modules/processing/curtain.py
+++ b/modules/processing/curtain.py
@@ -116,7 +116,7 @@ def buildBehaviors(entry, behaviorTags):
 
     behaviorCol["Invokes C# .NET Assemblies"] = [["Add-Type"]]
 
-    behaviorCol[""] = [["Win32_Shadowcopy"]]
+    behaviorCol["Modifies Shadowcopy"] = [["Win32_Shadowcopy"]]
 
     for event in entry:
         for message in entry[event]:

--- a/modules/processing/curtain.py
+++ b/modules/processing/curtain.py
@@ -114,7 +114,9 @@ def buildBehaviors(entry, behaviorTags):
 
     behaviorCol["Token Manipulation"] = [["CreateProcessWithTokenA"],["CreateProcessWithTokenW"],["AdjustTokenPrivileges"],["DuplicateToken"],["OpenProcessToken"],["WTSQueryUserToken"]]
 
-    behaviorCol["Modifies Shadowcopy"] = [["Win32_Shadowcopy"]]
+    behaviorCol["Invokes C# .NET Assemblies"] = [["Add-Type"]]
+
+    behaviorCol[""] = [["Win32_Shadowcopy"]]
 
     for event in entry:
         for message in entry[event]:


### PR DESCRIPTION
Add-Type basically can be used to trigger compiling of code with csc.exe (which also should fire some sigs)